### PR TITLE
Subscription confirmation journey

### DIFF
--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -21,6 +21,9 @@ body {background-color: #F1F1F1; margin: 0px;}
   ul { columns: 2; -webkit-columns: 2; -moz-columns: 2; }
 }
 
+/* email_subscribers/<ID>/send_confirmation */
+.send-confirmation { margin-bottom: 600px }
+
 /* Header */
 .header { padding: 0; display: block; text-align: left; background-color: #4D4D4E;
   .navbar { padding: 0; background-color: white; height: 50px; border-bottom: 1px solid rgba(77, 77, 78, 0.2); }
@@ -37,7 +40,6 @@ body {background-color: #F1F1F1; margin: 0px;}
       }
     }
   }
-
   .mainmenu { text-align: left; width: 600px; min-width: 500px; margin: 0 10px 0 10px;
     & > ul > li { float: left; margin-left: 15px; padding: 8px 0 0 8px;
       &:first-of-type { margin: 0 0 0 10px; padding: 8px 0 0 8px;}

--- a/app/assets/stylesheets/vars.scss
+++ b/app/assets/stylesheets/vars.scss
@@ -20,7 +20,8 @@ $grey-color-lighter:          #ccc;
 $grey-color-lightest:         #eee;
 $orange-color-hover:                #E5A636;
 
-$default-width:             930px;
-$on-tablet:               768px;
-$on-smaller-tablets:            640px;
-$on-phone:                480px;
+$default-width:               930px;
+$on-tablet:                   768px;
+$on-smaller-tablets:          640px;
+$on-phone:                    480px;
+$container-max-width:         600px;

--- a/app/controllers/email_subscribers_controller.rb
+++ b/app/controllers/email_subscribers_controller.rb
@@ -1,9 +1,12 @@
 class EmailSubscribersController < ApplicationController
   def create
     email = params[:email]
-    subscriber = EmailSubscriber.create!(email: email)
+    subscriber = EmailSubscriber.create!(email: email, confirmed: false)
     Rails.logger.info("New email subscriber: id##{subscriber.id}")
-    flash[:email_subscribed_notice] = "Subscribed! Check your inbox for confirmation."
+    redirect_to send_confirmation_email_subscriber_path(subscriber.id)
+  rescue ActiveRecord::RecordInvalid => e
+    flash[:validation_error] = e.message
+    Rails.logger.error("Could not save email subscription: #{e.message}")
     redirect_to "#{root_url}#subscribed"
   end
 
@@ -14,5 +17,16 @@ class EmailSubscribersController < ApplicationController
   rescue ActiveRecord::RecordNotFound => ex
     Rails.logger.info("#{ex}: Redirecting to homepage")
     redirect_to root_url
+  end
+
+  def send_confirmation
+    @email_subscriber = EmailSubscriber.find(params[:id])
+    EmailSubscriptionConfirmationMailer.send_confirmation(email_subscriber: @email_subscriber).deliver_now
+  end
+
+  def confirm
+    @email_subscriber = EmailSubscriber.find(params[:id])
+    @email_subscriber.confirm!
+    Rails.logger.info("Confirmed subscription for EmailSubscriber##{@email_subscriber.id}")
   end
 end

--- a/app/mailers/email_subscription_confirmation_mailer.rb
+++ b/app/mailers/email_subscription_confirmation_mailer.rb
@@ -1,0 +1,12 @@
+class EmailSubscriptionConfirmationMailer < ApplicationMailer
+  default from: "grubdaily <grubdaily@mail.grubdaily.com>"
+
+  def send_confirmation(email_subscriber:)
+    @email_subscriber = email_subscriber
+    @host = ActionMailer::Base.default_url_options[:host]
+    headers["List-Unsubscribe"] = delete_email_subscriber_url(id: @email_subscriber.id)
+
+    mail(to: @email_subscriber.email, subject: "Please confirm your Grubdaily subscription")
+    Rails.logger.info("Successfully sent subscription confirmation for EmailSubscriber##{@email_subscriber.id}")
+  end
+end

--- a/app/models/email_subscriber.rb
+++ b/app/models/email_subscriber.rb
@@ -4,7 +4,7 @@ class EmailSubscriber < ApplicationRecord
   EMAIL_PATTERN = "#{email_local_part_pattern}@#{email_domain_pattern}"
   EMAIL_REGEX = /\A#{EMAIL_PATTERN}\z/
 
-  validates :email, format: { with: EMAIL_REGEX, message: "is not valid" }
+  validates :email, format: { with: EMAIL_REGEX, message: "is an invalid format" }
   validates :email, uniqueness: { message: "is already subscribed"}
 
   scope :confirmed, -> { where(confirmed: true) }

--- a/app/models/email_subscriber.rb
+++ b/app/models/email_subscriber.rb
@@ -4,5 +4,12 @@ class EmailSubscriber < ApplicationRecord
   EMAIL_PATTERN = "#{email_local_part_pattern}@#{email_domain_pattern}"
   EMAIL_REGEX = /\A#{EMAIL_PATTERN}\z/
 
-  validates :email, format: { with: EMAIL_REGEX, message: "email is not valid" }
+  validates :email, format: { with: EMAIL_REGEX, message: "is not valid" }
+  validates :email, uniqueness: { message: "is already subscribed"}
+
+  scope :confirmed, -> { where(confirmed: true) }
+
+  def confirm!
+    self.update!(confirmed: true)
+  end
 end

--- a/app/services/bulk_recipe_emailer.rb
+++ b/app/services/bulk_recipe_emailer.rb
@@ -1,6 +1,6 @@
 class BulkRecipeEmailer
   def self.deliver_email_update(recipe)
-    EmailSubscriber.all.each do |email_subscriber|
+    EmailSubscriber.confirmed.each do |email_subscriber|
       RecipeMailer.new_recipe(recipe: recipe, email_subscriber: email_subscriber).deliver
     end
   end

--- a/app/views/email_subscribers/confirm.html.erb
+++ b/app/views/email_subscribers/confirm.html.erb
@@ -19,7 +19,7 @@ email update! If you want to unsubscribe, there will be a link in the footer of 
     </br>
 
     <p>
-      If you have any feedback or questions, feel free to message me; <strong>@grubdaily</strong> on Instagram or email me at <strong>tom@grubdaily.com</strong>
+      If you have any feedback or questions, feel free to message me; <strong>@grubdaily</strong> on Instagram or email <strong>tom@grubdaily.com</strong>
     </p>
 
     </br>

--- a/app/views/email_subscribers/confirm.html.erb
+++ b/app/views/email_subscribers/confirm.html.erb
@@ -1,0 +1,31 @@
+<div class="send-confirmation mt-6 mx-6">
+  <div class="container">
+    <h1 style="font-size: 30px">
+      You have successfully subscribed
+    </h1>
+
+    </br>
+
+    <p> Each time something tasty is added to grubdaily.com, you will receive an
+email update! If you want to unsubscribe, there will be a link in the footer of each email, or just click <%= link_to("here", delete_email_subscriber_url(@email_subscriber)) %>.
+    </p>
+
+    </br>
+
+    <p>
+      I hope you enjoy my recipes and general food chat :)
+    </p>
+
+    </br>
+
+    <p>
+      If you have any feedback or questions, feel free to message me; <strong>@grubdaily</strong> on Instagram or email me at <strong>tom@grubdaily.com</strong>
+    </p>
+
+    </br>
+
+    <p>Cheers!</p>
+    <p>Tom</p>
+  </div>
+</div>
+

--- a/app/views/email_subscribers/send_confirmation.html.erb
+++ b/app/views/email_subscribers/send_confirmation.html.erb
@@ -1,0 +1,22 @@
+<div class="send-confirmation mt-6 mx-6">
+  <div class="container">
+    <h1 style="font-size: 30px">
+      Thank you!
+    </h1>
+    <h1 style="font-size: 30px">
+      You're almost done ...
+    </h1>
+
+    </br>
+
+    <p>
+      <ol>
+        <li>Now check your email inbox.</li>
+        <li>Click on the confirmation link</li>
+        <li>Look forward to receiving tasty things in your inbox :)</li>
+        <li>Note: if you don't receive a confirmation email after 5 minutes, check your spam folder</li>
+      </ol>
+    </p>
+  </div>
+</div>
+

--- a/app/views/email_subscription_confirmation_mailer/send_confirmation.html.erb
+++ b/app/views/email_subscription_confirmation_mailer/send_confirmation.html.erb
@@ -1,0 +1,21 @@
+
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta content="text/html; charset=UTF-8" http-equiv="Content-Type" />
+  </head>
+  <body>
+    <p>
+      <img src="https://www.grubdaily.com/images/email-header-logo.png" width="600px" title="grubdaily" alt="grubdaily">
+    </p>
+
+    <h1 style="color: #E5A636;">
+        Please confirm your subscription
+    </h1>
+
+    <p style="max-width: 600px;">
+      Click <%= link_to("here", confirm_email_subscriber_url(@email_subscriber)) %>
+      to confirm your subscription to the grubdaily mailing list.
+    </p>
+  </body>
+</html>

--- a/app/views/email_subscription_confirmation_mailer/send_confirmation.text.erb
+++ b/app/views/email_subscription_confirmation_mailer/send_confirmation.text.erb
@@ -1,0 +1,3 @@
+Please confirm your Grubdaily subscription
+
+Click <%= link_to("here", confirm_email_subscriber_url(@email_subscriber)) %> to confirm your subscription to the grubdaily mailing list.

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -45,10 +45,10 @@
                   <%= form.submit value: "Go", class: "button is-medium submit-button" %>
               </div>
             </div>
-          <% end %>
 
-          <% if flash[:email_subscribed_notice] %>
-            <div class="notice"><%= flash[:email_subscribed_notice] %></div>
+            <% if flash[:validation_error] %>
+              <div class="notice"><%= flash[:validation_error].sub("Validation failed: Email", "Error: email") %></div>
+            <% end %>
           <% end %>
         </section>
       <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,8 @@ Rails.application.routes.draw do
   resources :email_subscribers do
     member do
       get :delete
+      get :send_confirmation
+      get :confirm
     end
   end
 

--- a/db/migrate/20201216201250_add_confirmed_to_email_subscribers.rb
+++ b/db/migrate/20201216201250_add_confirmed_to_email_subscribers.rb
@@ -1,0 +1,5 @@
+class AddConfirmedToEmailSubscribers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :email_subscribers, :confirmed, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_12_202745) do
+ActiveRecord::Schema.define(version: 2020_12_16_201250) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -19,6 +19,7 @@ ActiveRecord::Schema.define(version: 2020_11_12_202745) do
     t.string "email"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.boolean "confirmed"
   end
 
   create_table "ingredient_entries", force: :cascade do |t|

--- a/spec/mailers/previews/email_subscription_confirmation_mailer_preview.rb
+++ b/spec/mailers/previews/email_subscription_confirmation_mailer_preview.rb
@@ -1,0 +1,7 @@
+# Preview all emails at http://localhost:2020/rails/mailers/recipe_mailer
+class EmailSubscriptionConfirmationMailerPreview < ActionMailer::Preview
+  def send_confirmation
+    email_subscriber = EmailSubscriber.create!(email: "mail@example.com")
+    EmailSubscriptionConfirmationMailer.send_confirmation(email_subscriber: email_subscriber)
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -25,7 +25,7 @@ require 'capybara-screenshot/rspec'
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove this line.
-# ActiveRecord::Migration.maintain_test_schema!
+ActiveRecord::Migration.maintain_test_schema!
 
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures

--- a/spec/services/bulk_recipe_emailer_spec.rb
+++ b/spec/services/bulk_recipe_emailer_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe BulkRecipeEmailer, type: :model do
   describe "#deliver_email_update" do
-    let!(:email_subscriber) { EmailSubscriber.create(email: "mail@example.com") }
+    let!(:email_subscriber) { EmailSubscriber.create(email: "mail@example.com", confirmed: true) }
     let(:recipe) { FactoryBot.create(:recipe) }
 
      it "calls RecipeMailer" do


### PR DESCRIPTION
* Add migration for confirmed column
* Add controller action and view for send_confirmation
* Improved the styling of the send confirmation view
* Edit the RecipeMailer to only send to subscribers that have confirmed
* Create a mailer to send the confirmation email
* Add endpoint for marking the subscriber as confirmed
* Write content for the confirmation email, including the link to
  confirm the subscription
* Add validation on the email subscribers model
* Substitute the flash confirmation message with validation errors