### PR TITLE
Add https to default URL options in production config

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -64,7 +64,7 @@ Rails.application.configure do
   # config.active_job.queue_name_prefix = "grubdaily_rails_#{Rails.env}"
   config.action_mailer.perform_caching = false
 
-  config.action_mailer.default_url_options = { host: "www.grubdaily.com" }
+  config.action_mailer.default_url_options = { host: "https://www.grubdaily.com" }
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.


### PR DESCRIPTION
Previous to this change, all the links generated by `url_` helpers were not using https and were generating ssl warnings.