### PR TITLE
Fixes the autofocus on the menu page

### DIFF
--- a/app/javascript/packs/contactForm.js
+++ b/app/javascript/packs/contactForm.js
@@ -4,6 +4,7 @@ const subscribeElement = document.getElementById("subscribe-checkbox");
 const emailErrorDiv = document.querySelector(".email-error.form-error-message")
 const emailField = document.querySelector(".input.form-field.email")
 const formParentElement = document.getElementById("contact-form");
+const firstFormField = document.getElementById("first-form-field");
 
 const formFieldValueIsBlank = (formField) => (
   formField.value == "" || formField.value == null
@@ -13,6 +14,7 @@ const formFieldValueIsBlank = (formField) => (
 // which is the error div created by Rails upon redirect with the model errors
 if (errorFieldsArray.length > 0) {
   let blankFields = 0;
+  firstFormField.focus();
 
   // Remove the Rails error class so we can apply our own styles
   errorFieldsArray.forEach(errorField => {

--- a/app/views/orders/new.html.erb
+++ b/app/views/orders/new.html.erb
@@ -59,7 +59,7 @@
 
             <div class="field">
               <div class="control has-icons-left">
-                <%= form.text_field :name, required: true, class: "input form-field", autofocus: true, placeholder: "Name", autocomplete: "name" %>
+                <%= form.text_field :name, required: true, class: "input form-field", id: "first-form-field", placeholder: "Name", autocomplete: "name" %>
                 <span class="icon is-small is-left">
                   <i class="fas fa-user"></i>
                 </span>


### PR DESCRIPTION
This page was autofocusing on the first element of the form regardless
of whether there was an error or not. This commit uses the `focus()`
method in the contactForm.js file to focus on the first element only if
there are any errors present.